### PR TITLE
OAP-89 Introduce Maven enforcer plugin (3.1.0 version)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         # Java versions to run unit tests
-        java: [ '15' ]
+        java: [ '17' ]
       fail-fast: false
     steps:
     - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /.idea/jarRepositories.xml
 /.idea/workspace.xml
 /.idea/shelf
+/.idea/runConfigurations.xml
 
 target
 .surefire*

--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ The parent Maven OAP project. All Maven OAP projects should use it in the follow
     </parent>
 ```
 Currently it handles `maven-compiler-plugin`, `maven-surefire-plugin`, `maven-source-plugin`, `flatten-maven-plugin`, 
-`maven-checkstyle-plugin`.</br> 
+`maven-checkstyle-plugin`, `maven-enforcer-plugin`.</br> 
 _Note: the above plugins still can be overridden in child Maven project, if needed._

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${oap.deps.maven.enforcer.version}</version>
                 <executions>
                     <execution>
                         <id>validate_java_and_maven_version</id>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     </organization>
 
     <properties>
-        <oap.maven.project.version>17.3.6.0</oap.maven.project.version>
+        <oap.maven.project.version>17.3.6.1</oap.maven.project.version>
 
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
@@ -32,6 +32,8 @@
         <oap.deps.maven.flatten.version>1.2.2</oap.deps.maven.flatten.version>
         <oap.deps.maven.jar.version>3.2.2</oap.deps.maven.jar.version>
         <oap.deps.maven.compiler.version>3.8.0</oap.deps.maven.compiler.version>
+        <oap.deps.maven.enforcer.version>3.1.0</oap.deps.maven.enforcer.version>
+        <min.maven.version>3.6.3</min.maven.version>
     </properties>
 
     <build>
@@ -170,6 +172,29 @@
                         <version>${oap.deps.checkstyle.version}</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>validate_java_and_maven_version</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[${min.maven.version},4)</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>[${maven.compiler.source},18)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
It allows to fail the build in the beginning and print the correct message of required Maven and Java versions